### PR TITLE
Corrected src/Makefile and pinpointed typo in README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Yorick.
 ## Installation
 
 To install the library (not needed for IDL nor for IDL):
+##FIXME: Éric, you might want to check the sentence inside brackets.
 
 1. Edit the file `src/Makefile` (see "Portability Issues" below).
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -59,7 +59,7 @@ install: $(LIBNAME)
 	  $(INSTALL) optimpacklegacy.h "$(PREFIX)/include/."; \
 	  test -d "$(PREFIX)/doc/OptimPack-$${version}" || \
 	    mkdir -p "$(PREFIX)/doc/OptimPack-$${version}"; \
-	  $(INSTALL) $(srcdir)/../README $(srcdir)/../AUTHORS \
+	  $(INSTALL) $(srcdir)/../README.md $(srcdir)/../AUTHORS \
 	    $(srcdir)/../LICENSE $(srcdir)/optimpacklegacy.h \
 	    "$(PREFIX)/doc/OptimPack-$${version}/."; \
 	fi


### PR DESCRIPTION
Dear Éric,

I corrected the Makefile file inside src/ directory in order to correctly point to README.md and not to README. If this is not corrected, the installation yields an error at the 'make PREFIX=/usr/local/ install' stage. I am including in this message a text file with the output of the installation of OptimPackLegacy in my machine, in case you need to have a look at it. 

I also add a comment in README.md to pinpoint you a typo.

Cheers!

[optimpacklegacy_installation_output.txt](https://github.com/emmt/OptimPackLegacy/files/671498/optimpacklegacy_installation_output.txt)
