### PR TITLE
Sizes are long instead of int

### DIFF
--- a/matlab/m_opl_vmlmb_create.c
+++ b/matlab/m_opl_vmlmb_create.c
@@ -40,7 +40,7 @@ void mexFunction( int nlhs, mxArray *plhs[],
                   int nrhs, const mxArray *prhs[] )
 { 
     double fatol, frtol, sftol, sgtol, sxtol, epsilon, delta;
-    int n, m,size, fmin=FALSE;
+    long n, m,size, fmin=FALSE;
     mwSize dims[]={1,1};
     opl_vmlmb_workspace_t* ws;
       /* Control of the number of inputs and outputs */ 

--- a/matlab/m_opl_vmlmb_iterate.c
+++ b/matlab/m_opl_vmlmb_iterate.c
@@ -48,7 +48,7 @@ void mexFunction( int nlhs, mxArray *plhs[],
     double* h;
     int *task;
     opl_vmlmb_workspace_t* ws;
-    int n, m;
+    long n, m;
     
     if (nrhs < 4 || nrhs > 6) {
         mexErrMsgTxt("expecting between 4 and 6 arguments");

--- a/matlab/m_opl_vmlmb_restore.c
+++ b/matlab/m_opl_vmlmb_restore.c
@@ -47,7 +47,7 @@ void mexFunction( int nlhs, mxArray *plhs[],
     double* g;
     int  *task;
     opl_vmlmb_workspace_t* ws;
-    int n, m;
+    long n, m;
     
     if (nrhs != 4) {
         mexErrMsgTxt("expecting between 4 arguments");


### PR DESCRIPTION
Fix size problem for large array in the matlab wrapper 